### PR TITLE
Give the profile command be able to be sent with ephemeral messages.

### DIFF
--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -1,4 +1,4 @@
-```js
+
 /**
  * Copyright (C) 2021 PythonCoderAS
  *
@@ -75,4 +75,4 @@ Screening Sent on Saturday: **${autoDayData.onSaturday}**`;
     const isEphemeral = interaction.options.getBoolean("ephemeral")!;
     await interaction.reply({ embeds: [embed] , ephemeral: isEphemeral});
   },
-};```
+};

--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -1,4 +1,3 @@
-
 /**
  * Copyright (C) 2021 PythonCoderAS
  *
@@ -26,7 +25,7 @@ import getDeviceData from "../screeningClient/getUserInfo/getDeviceData";
 module.exports = {
   data: new SlashCommandBuilder()
     .setName("profile")
-    .setDescription("Saw profile."),
+    .setDescription("Saw profile.")
     .addBooleanOption((option) =>
       option
         .setName("ephemeral")
@@ -72,6 +71,6 @@ Screening Sent on Saturday: **${autoDayData.onSaturday}**`;
       embed.addField("Auto Day", "**No data**");
     }
     embed.addField("Device Used for Screenings", deviceData.device);
-    await interaction.reply({ embeds: [embed] , ephemeral: isEphemeral });
+    await interaction.reply({ embeds: [embed], ephemeral: isEphemeral });
   },
 };

--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -32,8 +32,9 @@ module.exports = {
         .setName("ephemeral")
         .setDescription("Whether to hide this message.")
         .setRequired(true)
-    )
+    ),
   async execute(interaction: CommandInteraction) {
+    const isEphemeral = interaction.options.getBoolean("ephemeral")!;
     const autoData = await getAutoData({ userId: interaction.user.id });
     const autoDayData = await getAutoDayData({ userId: interaction.user.id });
     const deviceData = await getDeviceData({ userId: interaction.user.id });
@@ -71,8 +72,6 @@ Screening Sent on Saturday: **${autoDayData.onSaturday}**`;
       embed.addField("Auto Day", "**No data**");
     }
     embed.addField("Device Used for Screenings", deviceData.device);
-    
-    const isEphemeral = interaction.options.getBoolean("ephemeral")!;
-    await interaction.reply({ embeds: [embed] , ephemeral: isEphemeral});
+    await interaction.reply({ embeds: [embed] , ephemeral: isEphemeral });
   },
 };

--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -1,3 +1,4 @@
+```js
 /**
  * Copyright (C) 2021 PythonCoderAS
  *
@@ -26,6 +27,12 @@ module.exports = {
   data: new SlashCommandBuilder()
     .setName("profile")
     .setDescription("Saw profile."),
+    .addBooleanOption((option) =>
+      option
+        .setName("ephemeral")
+        .setDescription("Whether to hide this message.")
+        .setRequired(true)
+    )
   async execute(interaction: CommandInteraction) {
     const autoData = await getAutoData({ userId: interaction.user.id });
     const autoDayData = await getAutoDayData({ userId: interaction.user.id });
@@ -64,6 +71,8 @@ Screening Sent on Saturday: **${autoDayData.onSaturday}**`;
       embed.addField("Auto Day", "**No data**");
     }
     embed.addField("Device Used for Screenings", deviceData.device);
-    await interaction.reply({ embeds: [embed] });
+    
+    const isEphemeral = interaction.options.getBoolean("ephemeral")!;
+    await interaction.reply({ embeds: [embed] , ephemeral: isEphemeral});
   },
-};
+};```


### PR DESCRIPTION
I think this code is valid so
I just made this pull requests because I don't like how you can have some sensitive information portrayed to other people to the server such as email and name. So this pull requests essentially just gives you the option to set it so the message sent with the profile info can be ephemeral. SO yea

⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣠⣴⣶⣿⣿⣷⣶⣄⣀⣀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⣰⣾⣿⣿⡿⢿⣿⣿⣿⣿⣿⣿⣿⣷⣦⡀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⢀⣾⣿⣿⡟⠁⣰⣿⣿⣿⡿⠿⠻⠿⣿⣿⣿⣿⣧⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⣾⣿⣿⠏⠀⣴⣿⣿⣿⠉⠀⠀⠀⠀⠀⠈⢻⣿⣿⣇⠀⠀⠀
⠀⠀⠀⠀⢀⣠⣼⣿⣿⡏⠀⢠⣿⣿⣿⠇⠀⠀⠀⠀⠀⠀⠀⠈⣿⣿⣿⡀⠀⠀
⠀⠀⠀⣰⣿⣿⣿⣿⣿⡇⠀⢸⣿⣿⣿⡀⠀⠀⠀⠀⠀⠀⠀⠀⣿⣿⣿⡇⠀⠀
⠀⠀⢰⣿⣿⡿⣿⣿⣿⡇⠀⠘⣿⣿⣿⣧⠀⠀⠀⠀⠀⠀⢀⣸⣿⣿⣿⠁⠀⠀
⠀⠀⣿⣿⣿⠁⣿⣿⣿⡇⠀⠀⠻⣿⣿⣿⣷⣶⣶⣶⣶⣶⣿⣿⣿⣿⠃⠀⠀⠀
⠀⢰⣿⣿⡇⠀⣿⣿⣿⠀⠀⠀⠀⠈⠻⣿⣿⣿⣿⣿⣿⣿⣿⣿⠟⠁⠀⠀⠀⠀
⠀⢸⣿⣿⡇⠀⣿⣿⣿⠀⠀⠀⠀⠀⠀⠀⠉⠛⠛⠛⠉⢉⣿⣿⠀⠀⠀⠀⠀⠀
⠀⢸⣿⣿⣇⠀⣿⣿⣿⠀⠀⠀⠀⠀⢀⣤⣤⣤⡀⠀⠀⢸⣿⣿⣿⣷⣦⠀⠀⠀
⠀⠀⢻⣿⣿⣶⣿⣿⣿⠀⠀⠀⠀⠀⠈⠻⣿⣿⣿⣦⡀⠀⠉⠉⠻⣿⣿⡇⠀⠀
⠀⠀⠀⠛⠿⣿⣿⣿⣿⣷⣤⡀⠀⠀⠀⠀⠈⠹⣿⣿⣇⣀⠀⣠⣾⣿⣿⡇⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠹⣿⣿⣿⣿⣦⣤⣤⣤⣤⣾⣿⣿⣿⣿⣿⣿⣿⣿⡟⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠻⢿⣿⣿⣿⣿⣿⣿⠿⠋⠉⠛⠋⠉⠉⠁⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠉⠉⠉⠁
this is my first time working with ts btw