### PR TITLE
Add type annotations to default config steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,13 @@ The file needs to export three named objects (the name _must_ be the same):
 
 #### `database`
 
-This is an object for the database. ~~If you are using sqlite3 (highly recommended because it does not require you to install any additional software), export an object that looks like this:
+This is an object for the database. 
 
+~~If you are using sqlite3 (highly recommended because it does not require you to install any additional software), import the Options type from sequelize and export an object like so:~~
 ```typescript
-export const database = {
+import { Options } from "sequelize";
+
+export const database: Options = {
   dialect: "sqlite",
   storage: "./db.sqlite",
 };
@@ -56,7 +59,9 @@ export const database = {
 If you are using Postgres (**REQUIRED**), export an object that looks like this:
 
 ```typescript
-export const database = {
+import { Options } from "sequelize";
+
+export const database: Options = {
   dialect: "postgres",
   username: "user",
   password: "user",

--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ The file needs to export three named objects (the name _must_ be the same):
 
 #### `database`
 
-This is an object for the database. 
+This is an object for the database.
 
 ~~If you are using sqlite3 (highly recommended because it does not require you to install any additional software), import the Options type from sequelize and export an object like so:~~
+
 ```typescript
 import { Options } from "sequelize";
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ export const github = {
 When complete, the `config.ts` file should look like this:
 
 ```typescript
-export const database = {
+import { Options } from "sequelize";
+
+export const database: Options = {
   dialect: "postgres",
   username: "user",
   password: "user",


### PR DESCRIPTION
The README did not mention that TypeScript annotations were needed to get the `database` object to be accepted by sequelize, leading to a broken build state if one were to follow the instructions word by word.

I have updated the SQLite instructions too, as I have yet to find any regressions when using a local SQLite database as opposed to the "required" Postgres database.